### PR TITLE
reference to not minified version of main file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "description": "jQuery Easing plugin",
   "homepage": "http://gsgd.co.uk/sandbox/jquery/easing/",
-  "main": "js/jquery.easing.min.js",
+  "main": "js/jquery.easing.js",
   "keywords": [
     "jquery",
     "jquery plugin",


### PR DESCRIPTION
If this package is used within a build process (e.g. yo web app), referencing minified versions of packages will cause errors during build

This topic has been discussed multiple times... and making this change actually helped me to optimise my web application.

https://groups.google.com/forum/#!msg/twitter-bower/P8TbooJPacs/Qxy40Gcp2o0J

https://github.com/bower/bower/issues/368

and even been adopted in packages like bootstrap:

https://github.com/twbs/bootstrap/pull/9493
